### PR TITLE
fix: Empire 7.0 MITRE loader, working md format, no checkout writes

### DIFF
--- a/advanced_reporting.py
+++ b/advanced_reporting.py
@@ -182,9 +182,6 @@ class Plugin(BasePlugin):
     def credential_report(self, db, user, fmt):
         creds = [("Domain", "Username", "Host", "Cred Type", "Password")]
         for row in db.query(models.Credential).all():
-            # append, not extend: extend flattened each credential into five
-            # separate entries, and tabulate then rendered every bare string as
-            # its own row, one character per cell.
             creds.append(
                 [row.domain, row.username, row.host, row.credtype, row.password]
             )
@@ -223,15 +220,12 @@ class Plugin(BasePlugin):
         # Pull all techniques from MITRE database
         techniques = self.Attack(self.main_menu).all_attacks()
 
-        # Map each declared technique id to the modules that were tasked with
-        # it. Keyed by technique and deduplicated by module, because the old
-        # parallel-list approach walked one entry per *task* and resolved the
-        # module name with list.index -- so a module tasked 200 times emitted
-        # its technique block 200 times, and two modules sharing a technique
-        # list both resolved to whichever was tasked first.
+        # Keyed by technique and deduplicated by module: a module tasked 200
+        # times declares its techniques once.
         modules_by_technique: dict[str, set[str]] = {}
         tasked_module_ids = {
-            task.module_name for task in db.query(models.AgentTask).all()
+            module_name
+            for (module_name,) in db.query(models.AgentTask.module_name).distinct()
         }
         for module_id in tasked_module_ids:
             module = self.main_menu.modulesv2.modules.get(module_id)
@@ -249,8 +243,8 @@ class Plugin(BasePlugin):
             except (KeyError, IndexError):
                 continue
 
-            # Substring rather than equality, preserving the original match: a
-            # module declaring T1059 also covers sub-techniques like T1059.001.
+            # Substring, not equality: a module declaring T1059 also covers
+            # sub-techniques like T1059.001.
             module_names = sorted(
                 {
                     name
@@ -263,13 +257,13 @@ class Plugin(BasePlugin):
                 continue
 
             used_techniques.append("<h3>" + technique["name"] + "</h3>")
-            # " / " not ", ": module_report_template.md renders the technique
-            # list with |replace(",", ""), which would strip a comma separator
-            # and run the module names together.
+            # " / " not ", ": the template renders this list through
+            # |replace(",", ""), which strips a comma separator.
             used_techniques.append(
                 "**Empire Modules Used:** " + " / ".join(module_names) + "<br><br>"
             )
-            used_techniques.append(technique._inner["description"])
+            # Revoked techniques carry no description (129 of 670 in v8.2).
+            used_techniques.append(technique._inner.get("description", ""))
 
         # Add data to Jinja2 Template
         template_vars = {"logo": self.logo, "techniques": used_techniques}
@@ -280,9 +274,7 @@ class Plugin(BasePlugin):
 
     def generate_and_upload_report(self, db, user, template_vars, report_name, fmt):
         # Render into a temp directory: the plugin directory is source, not an
-        # output location. The old code wrote {report_name}.pdf into it on every
-        # run, which dirtied the install tree and left stale PDFs -- the exact
-        # files the fixed-.pdf upload below used to attach by mistake.
+        # output location. create_download copies the file out before cleanup.
         with tempfile.TemporaryDirectory() as tmp_dir:
             tmp_dir = Path(tmp_dir)
             report = self.generate_report(
@@ -293,10 +285,7 @@ class Plugin(BasePlugin):
                 fmt=fmt,
             )
 
-            # Upload whichever file the requested format actually produced.
-            # This used to be a hardcoded .pdf, so `md` either raised
-            # FileNotFoundError or silently attached a stale PDF left behind by
-            # an earlier `pdf` run.
+            # Whichever file the requested format produced, not a fixed .pdf.
             return self.main_menu.downloadsv2.create_download(db, user, Path(report))
 
 

--- a/advanced_reporting.py
+++ b/advanced_reporting.py
@@ -1,6 +1,5 @@
 import io
 import tempfile
-import threading
 from pathlib import Path
 from typing import override
 
@@ -16,8 +15,6 @@ from .mitre import Attack
 
 
 class Plugin(BasePlugin):
-    lock = threading.Lock()
-
     @override
     def on_load(self, db):
         self.execution_options = {
@@ -64,7 +61,8 @@ class Plugin(BasePlugin):
             plugin_id=self.info.id,
             input=input,
             input_full=input,
-            user_id=user.id,
+            # None on the auto_execute path, where there is no request user.
+            user_id=user.id if user else None,
             status=PluginTaskStatus.completed,
         )
         output = ""
@@ -184,7 +182,10 @@ class Plugin(BasePlugin):
     def credential_report(self, db, user, fmt):
         creds = [("Domain", "Username", "Host", "Cred Type", "Password")]
         for row in db.query(models.Credential).all():
-            creds.extend(
+            # append, not extend: extend flattened each credential into five
+            # separate entries, and tabulate then rendered every bare string as
+            # its own row, one character per cell.
+            creds.append(
                 [row.domain, row.username, row.host, row.credtype, row.password]
             )
 
@@ -222,45 +223,50 @@ class Plugin(BasePlugin):
         # Pull all techniques from MITRE database
         techniques = self.Attack(self.main_menu).all_attacks()
 
-        # Pull task data from database
-        data = db.query(models.AgentTask).all()
+        # Map each declared technique id to the modules that were tasked with
+        # it. Keyed by technique and deduplicated by module, because the old
+        # parallel-list approach walked one entry per *task* and resolved the
+        # module name with list.index -- so a module tasked 200 times emitted
+        # its technique block 200 times, and two modules sharing a technique
+        # list both resolved to whichever was tasked first.
+        modules_by_technique: dict[str, set[str]] = {}
+        tasked_module_ids = {
+            task.module_name for task in db.query(models.AgentTask).all()
+        }
+        for module_id in tasked_module_ids:
+            module = self.main_menu.modulesv2.modules.get(module_id)
+            if module is None:
+                continue
+            for technique_id in module.techniques:
+                modules_by_technique.setdefault(technique_id, set()).add(module.name)
 
-        ttp = list([])
-        module_name = list([])
-        for task in data:
+        used_techniques = []
+        for technique in techniques:
             try:
-                module_name.append(
-                    self.main_menu.modulesv2.modules[task.module_name].name
-                )
-                ttp.append(
-                    self.main_menu.modulesv2.modules[task.module_name].techniques
-                )
-            except KeyError:
-                pass
+                external_id = technique._inner["external_references"][0]._inner[
+                    "external_id"
+                ]
+            except (KeyError, IndexError):
+                continue
 
-        # Create list of techniques
-        used_techniques = list([])
-        for ttp_list in ttp:
-            for ttp_name in ttp_list:
-                for i in range(len(techniques)):
-                    if (
-                        ttp_name
-                        in techniques[i]
-                        ._inner["external_references"][0]
-                        ._inner["external_id"]
-                    ):
-                        try:
-                            used_techniques.append(
-                                "<h3>" + techniques[i]["name"] + "</h3>"
-                            )
-                            used_techniques.append(
-                                "**Empire Modules Used:** "
-                                + module_name[ttp.index(ttp_list)]
-                                + "<br><br>"
-                            )
-                            used_techniques.append(techniques[i]._inner["description"])
-                        except Exception:
-                            pass
+            # Substring rather than equality, preserving the original match: a
+            # module declaring T1059 also covers sub-techniques like T1059.001.
+            module_names = sorted(
+                {
+                    name
+                    for technique_id, names in modules_by_technique.items()
+                    if technique_id in external_id
+                    for name in names
+                }
+            )
+            if not module_names:
+                continue
+
+            used_techniques.append("<h3>" + technique["name"] + "</h3>")
+            used_techniques.append(
+                "**Empire Modules Used:** " + ", ".join(module_names) + "<br><br>"
+            )
+            used_techniques.append(technique._inner["description"])
 
         # Add data to Jinja2 Template
         template_vars = {"logo": self.logo, "techniques": used_techniques}

--- a/advanced_reporting.py
+++ b/advanced_reporting.py
@@ -1,4 +1,5 @@
 import io
+import tempfile
 import threading
 from pathlib import Path
 from typing import override
@@ -258,7 +259,7 @@ class Plugin(BasePlugin):
                                 + "<br><br>"
                             )
                             used_techniques.append(techniques[i]._inner["description"])
-                        except:
+                        except Exception:
                             pass
 
         # Add data to Jinja2 Template
@@ -269,21 +270,24 @@ class Plugin(BasePlugin):
         )
 
     def generate_and_upload_report(self, db, user, template_vars, report_name, fmt):
-        pdf_out = self.plugin_dir / f"{report_name}.pdf"
-        md_out = self.plugin_dir / "markdown" / f"{report_name}.md"
+        # Render into a temp directory. The plugin directory is a git checkout
+        # that gets updated and reinstalled in place, so it shouldn't accumulate
+        # generated reports.
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            tmp_dir = Path(tmp_dir)
+            report = self.generate_report(
+                md_template=f"{report_name.lower()}_template.md",
+                temp_var=template_vars,
+                md_file=str(tmp_dir / f"{report_name}.md"),
+                pdf_out=str(tmp_dir / f"{report_name}.pdf"),
+                fmt=fmt,
+            )
 
-        self.generate_report(
-            md_template=f"{report_name.lower()}_template.md",
-            temp_var=template_vars,
-            md_file=str(md_out),
-            pdf_out=str(pdf_out),
-            fmt=fmt,
-        )
-
-        test_upload = self.plugin_dir / f"{report_name}.pdf"
-        db_download = self.main_menu.downloadsv2.create_download(db, user, test_upload)
-
-        return db_download
+            # Upload whichever file the requested format actually produced.
+            # This used to be a hardcoded .pdf, so `md` either raised
+            # FileNotFoundError or silently attached a stale PDF left behind by
+            # an earlier `pdf` run.
+            return self.main_menu.downloadsv2.create_download(db, user, Path(report))
 
 
 def xstr(s):

--- a/advanced_reporting.py
+++ b/advanced_reporting.py
@@ -263,8 +263,11 @@ class Plugin(BasePlugin):
                 continue
 
             used_techniques.append("<h3>" + technique["name"] + "</h3>")
+            # " / " not ", ": module_report_template.md renders the technique
+            # list with |replace(",", ""), which would strip a comma separator
+            # and run the module names together.
             used_techniques.append(
-                "**Empire Modules Used:** " + ", ".join(module_names) + "<br><br>"
+                "**Empire Modules Used:** " + " / ".join(module_names) + "<br><br>"
             )
             used_techniques.append(technique._inner["description"])
 
@@ -276,9 +279,10 @@ class Plugin(BasePlugin):
         )
 
     def generate_and_upload_report(self, db, user, template_vars, report_name, fmt):
-        # Render into a temp directory. The plugin directory is a git checkout
-        # that gets updated and reinstalled in place, so it shouldn't accumulate
-        # generated reports.
+        # Render into a temp directory: the plugin directory is source, not an
+        # output location. The old code wrote {report_name}.pdf into it on every
+        # run, which dirtied the install tree and left stale PDFs -- the exact
+        # files the fixed-.pdf upload below used to attach by mistake.
         with tempfile.TemporaryDirectory() as tmp_dir:
             tmp_dir = Path(tmp_dir)
             report = self.generate_report(

--- a/mitre.py
+++ b/mitre.py
@@ -1,13 +1,10 @@
 import json
-import os
 import tarfile
 import urllib.request
 from itertools import chain
 
 from stix2 import FileSystemSource, Filter
 from stix2.utils import get_type_from_id
-
-from empire.server.common import helpers
 
 
 class Attack:
@@ -72,26 +69,20 @@ class Attack:
 
     # mitre defined functions
     def load_database(self):
-        try:
-            # If database doesn't exist then download it
-            database_tar = self.main_menu.installPath + "/data/cti.tar.gz"
-            if not os.path.isfile(
-                self.main_menu.installPath + "/data/cti/enterprise-attack"
-            ):
-                urllib.request.urlretrieve(
-                    "https://github.com/mitre/cti/archive/refs/tags/ATT&CK-v8.2.tar.gz",
-                    filename=database_tar,
-                )
-                if database_tar.endswith("tar.gz"):
-                    tar = tarfile.open(database_tar, "r:gz")
-                    tar.extractall(path=self.main_menu.installPath + "/data")
-                    tar.close()
-            fs = FileSystemSource(
-                self.main_menu.installPath + "/data/cti-ATT-CK-v8.2/enterprise-attack"
+        data_dir = self.main_menu.install_path / "data"
+        attack_dir = data_dir / "cti-ATT-CK-v8.2" / "enterprise-attack"
+
+        # If database doesn't exist then download it
+        if not attack_dir.is_dir():
+            database_tar = data_dir / "cti.tar.gz"
+            urllib.request.urlretrieve(
+                "https://github.com/mitre/cti/archive/refs/tags/ATT&CK-v8.2.tar.gz",
+                filename=database_tar,
             )
-            return fs
-        except Exception as e:
-            print(helpers.color(f"[!] Error: {e}"))
+            with tarfile.open(database_tar, "r:gz") as tar:
+                tar.extractall(path=data_dir, filter="data")
+
+        return FileSystemSource(str(attack_dir))
 
     def get_all_software(self, src):
         filts = [[Filter("type", "=", "malware")], [Filter("type", "=", "tool")]]

--- a/mitre.py
+++ b/mitre.py
@@ -72,13 +72,9 @@ class Attack:
     def load_database(self):
         data_dir = self.main_menu.install_path / "data"
         attack_dir = data_dir / "cti-ATT-CK-v8.2" / "enterprise-attack"
-        # Written only after a full extraction, and gated on instead of the
-        # directory's mere existence. FileSystemSource accepts a partially
-        # populated enterprise-attack/ without error -- a query for a type whose
-        # subdir is missing just returns [], i.e. a silently empty report -- so
-        # an is_dir() check would trust a truncated tree (e.g. one an
-        # interrupted 6.x run left behind, since 6.x re-extracted over data/
-        # every run) forever. The marker forces a clean re-extract instead.
+        # Gated on a marker rather than the directory existing: FileSystemSource
+        # serves a partially extracted tree without error, returning [] for any
+        # missing type, so a truncated tree would report empty forever.
         complete_marker = attack_dir.parent / ".empire_complete"
 
         if not complete_marker.is_file():
@@ -88,19 +84,15 @@ class Attack:
                     "https://github.com/mitre/cti/archive/refs/tags/ATT&CK-v8.2.tar.gz",
                     filename=database_tar,
                 )
-                # Extract to a staging dir and move into place, so an
-                # interrupted extraction (disk full, OOM, SIGKILL) can't leave a
-                # half-written tree that the marker below would then bless.
+                # Stage and move, so an interrupted extraction can't leave a
+                # half-written tree for the marker below to bless.
                 staging = data_dir / "cti-staging"
                 if staging.is_dir():
                     shutil.rmtree(staging)
                 with tarfile.open(database_tar, "r:gz") as tar:
                     tar.extractall(path=staging, filter="data")
-                # Clear any leftover tree before the rename: renaming onto a
-                # non-empty directory raises ENOTEMPTY, which would wedge every
-                # later run. A partial cti-ATT-CK-v8.2/ from an interrupted 6.x
-                # extraction -- or one an operator half-deleted to force a
-                # refresh -- is exactly the state that reaches here.
+                # Renaming onto a non-empty directory raises ENOTEMPTY, and a
+                # leftover partial tree is exactly what reaches here.
                 shutil.rmtree(attack_dir.parent, ignore_errors=True)
                 (staging / attack_dir.parent.name).rename(attack_dir.parent)
                 complete_marker.touch()

--- a/mitre.py
+++ b/mitre.py
@@ -72,9 +72,16 @@ class Attack:
     def load_database(self):
         data_dir = self.main_menu.install_path / "data"
         attack_dir = data_dir / "cti-ATT-CK-v8.2" / "enterprise-attack"
+        # Written only after a full extraction, and gated on instead of the
+        # directory's mere existence. FileSystemSource accepts a partially
+        # populated enterprise-attack/ without error -- a query for a type whose
+        # subdir is missing just returns [], i.e. a silently empty report -- so
+        # an is_dir() check would trust a truncated tree (e.g. one an
+        # interrupted 6.x run left behind, since 6.x re-extracted over data/
+        # every run) forever. The marker forces a clean re-extract instead.
+        complete_marker = attack_dir.parent / ".empire_complete"
 
-        # If database doesn't exist then download it
-        if not attack_dir.is_dir():
+        if not complete_marker.is_file():
             database_tar = data_dir / "cti.tar.gz"
             try:
                 urllib.request.urlretrieve(
@@ -83,15 +90,20 @@ class Attack:
                 )
                 # Extract to a staging dir and move into place, so an
                 # interrupted extraction (disk full, OOM, SIGKILL) can't leave a
-                # partial cti-ATT-CK-v8.2/ behind. The existence check above
-                # would then take the fast path forever and silently serve a
-                # truncated technique set with no way to re-download.
+                # half-written tree that the marker below would then bless.
                 staging = data_dir / "cti-staging"
                 if staging.is_dir():
                     shutil.rmtree(staging)
                 with tarfile.open(database_tar, "r:gz") as tar:
                     tar.extractall(path=staging, filter="data")
+                # Clear any leftover tree before the rename: renaming onto a
+                # non-empty directory raises ENOTEMPTY, which would wedge every
+                # later run. A partial cti-ATT-CK-v8.2/ from an interrupted 6.x
+                # extraction -- or one an operator half-deleted to force a
+                # refresh -- is exactly the state that reaches here.
+                shutil.rmtree(attack_dir.parent, ignore_errors=True)
                 (staging / attack_dir.parent.name).rename(attack_dir.parent)
+                complete_marker.touch()
             finally:
                 database_tar.unlink(missing_ok=True)
                 shutil.rmtree(data_dir / "cti-staging", ignore_errors=True)

--- a/mitre.py
+++ b/mitre.py
@@ -1,4 +1,5 @@
 import json
+import shutil
 import tarfile
 import urllib.request
 from itertools import chain
@@ -75,12 +76,25 @@ class Attack:
         # If database doesn't exist then download it
         if not attack_dir.is_dir():
             database_tar = data_dir / "cti.tar.gz"
-            urllib.request.urlretrieve(
-                "https://github.com/mitre/cti/archive/refs/tags/ATT&CK-v8.2.tar.gz",
-                filename=database_tar,
-            )
-            with tarfile.open(database_tar, "r:gz") as tar:
-                tar.extractall(path=data_dir, filter="data")
+            try:
+                urllib.request.urlretrieve(
+                    "https://github.com/mitre/cti/archive/refs/tags/ATT&CK-v8.2.tar.gz",
+                    filename=database_tar,
+                )
+                # Extract to a staging dir and move into place, so an
+                # interrupted extraction (disk full, OOM, SIGKILL) can't leave a
+                # partial cti-ATT-CK-v8.2/ behind. The existence check above
+                # would then take the fast path forever and silently serve a
+                # truncated technique set with no way to re-download.
+                staging = data_dir / "cti-staging"
+                if staging.is_dir():
+                    shutil.rmtree(staging)
+                with tarfile.open(database_tar, "r:gz") as tar:
+                    tar.extractall(path=staging, filter="data")
+                (staging / attack_dir.parent.name).rename(attack_dir.parent)
+            finally:
+                database_tar.unlink(missing_ok=True)
+                shutil.rmtree(data_dir / "cti-staging", ignore_errors=True)
 
         return FileSystemSource(str(attack_dir))
 
@@ -252,4 +266,3 @@ class Attack:
             revoked_by = revoked_by[0]
 
         return revoked_by
-


### PR DESCRIPTION
## Summary

### Empire 7.0 compatibility (blocking)

`Attack.load_database()` built its paths from `main_menu.installPath`, removed in 7.0. A rename isn't enough — `install_path` is a `Path` now, and the surrounding code did `path + "/data"` and `.endswith(...)`. Rewritten to the `Path` idiom. The failure also presented badly: `load_database` swallowed it and returned `None`, so every report died later at `'NoneType' object has no attribute 'query'` rather than at the cause.

`execute()` dereferenced `user.id` unguarded, but `auto_execute_plugins` calls it with `user=None`. Anyone who configured auto_execute for this plugin got an `AttributeError` at startup and no report. `PluginTask.user_id` is already nullable.

### Broken in the same pass

**Two of the five reports were unusable.** `credential_report` used `extend` where it meant `append`, flattening each credential into five entries; `tabulate` then rendered every bare string as its own row, one character per cell — a PDF spelling every credential out letter by letter, under a header row convincing enough not to read as a crash. `module_report` walked one entry per *task* and resolved the module name with `list.index`, so a module tasked 200 times emitted its technique block 200 times, and two modules sharing a technique both resolved to whichever was tasked first — naming the wrong module. Rebuilt as technique → modules; the substring match is preserved, so T1059 still covers T1059.001.

**`md` never worked.** `generate_and_upload_report` discarded `generate_report`'s return value and always uploaded `{report_name}.pdf`. `md` is a `Strict` suggested value, so picking it either raised `FileNotFoundError` — after `create_download` had already left a 0-byte file in the operator's downloads — or silently attached a stale PDF from an earlier `pdf` run. Reports also rendered into the plugin's own source directory; they use a temp directory now.

**The ATT&CK cache could wedge or silently mislead.** Extraction is staged and moved, the target cleared first (renaming onto a leftover tree raises `ENOTEMPTY`), the 50MB tarball cleaned up, and completion recorded with a marker file — `is_dir()` trusted a truncated tree, which `FileSystemSource` serves without error as an empty report.

**Smaller:** revoked techniques (129 of 670 in v8.2) carry no `description`, which aborted the whole run for any module declaring a legacy id; the module list joins with `" / "` because the template strips commas; the bare `except:` swallowed `KeyboardInterrupt`.

**Not addressed, pre-existing:** both templates run `|replace(",", "")`, which strips every comma from technique prose and not just the separator, and `parse_json()` / `threat_filtering()` call an undefined `self.disable_modules(...)`.

**Review process:** audited against `docs/plugins/development/migration.md`, then two passes against Empire 7.0 core → `/code-review high`, findings classified new-vs-pre-existing. The v8.2 claims were checked against the real bundle and all 245 technique ids shipped in 7.0-dev rather than inferred. Not runtime-tested; needs the CTI download and a populated database.
